### PR TITLE
chore: add Vercel production logs for upstream API errors

### DIFF
--- a/src/app/api/brainstorm/route.ts
+++ b/src/app/api/brainstorm/route.ts
@@ -200,6 +200,19 @@ export async function POST(request: Request) {
   let questions: Record<string, unknown> | null = null;
   let end: Record<string, unknown> | null = null;
 
+  // Log a bit of runtime config in production so Vercel Logs can show what's wrong.
+  // Do NOT log the API key itself.
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("[brainstorm] Missing ANTHROPIC_API_KEY", {
+      sessionId: body.sessionId,
+      action: body.action,
+      language: body.language,
+      historyCount: body.history.length,
+      model: defaultModel,
+      baseURL: process.env.ANTHROPIC_BASE_URL || "default",
+    });
+  }
+
   try {
     const message = await createMessage(true);
     const content = message.content ?? [];
@@ -247,8 +260,30 @@ export async function POST(request: Request) {
         text = fallbackText || text;
       }
     }
-  } catch {
-    return new Response(JSON.stringify({ error: "Failed to fetch questions" }), { status: 500 });
+  } catch (err) {
+    const e = err as Record<string, unknown>;
+    const status = typeof e.status === "number" ? e.status : undefined;
+    const message = err instanceof Error ? err.message : String(err);
+
+    console.error("[brainstorm] Upstream API error", {
+      sessionId: body.sessionId,
+      action: body.action,
+      language: body.language,
+      historyCount: body.history.length,
+      model: defaultModel,
+      baseURL: process.env.ANTHROPIC_BASE_URL || "default",
+      status,
+      message,
+    });
+
+    return new Response(
+      JSON.stringify({
+        error: "Failed to fetch questions",
+        upstreamStatus: status,
+        message,
+      }),
+      { status: 500 },
+    );
   }
 
   const responseStream = new ReadableStream({

--- a/src/app/api/summary/route.ts
+++ b/src/app/api/summary/route.ts
@@ -79,6 +79,18 @@ export async function POST(request: Request) {
     .map((item, index) => `Q${index + 1}: ${item.question}\nA${index + 1}: ${item.answer}`)
     .join("\n");
 
+  // Log a bit of runtime config in production so Vercel Logs can show what's wrong.
+  // Do NOT log the API key itself.
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.error("[summary] Missing ANTHROPIC_API_KEY", {
+      sessionId: body.sessionId,
+      language: body.language,
+      historyCount: body.history.length,
+      model: defaultModel,
+      baseURL: process.env.ANTHROPIC_BASE_URL || "default",
+    });
+  }
+
   try {
     const markdownResponse = await client.messages.create({
       model: defaultModel,
@@ -102,8 +114,22 @@ export async function POST(request: Request) {
     if (markdownContent.trim()) {
       return Response.json({ summary: null, markdown: markdownContent });
     }
-  } catch {
-    // fall through
+  } catch (err) {
+    const e = err as Record<string, unknown>;
+    const status = typeof e.status === "number" ? e.status : undefined;
+    const message = err instanceof Error ? err.message : String(err);
+
+    console.error("[summary] Upstream API error (markdown attempt)", {
+      sessionId: body.sessionId,
+      language: body.language,
+      historyCount: body.history.length,
+      model: defaultModel,
+      baseURL: process.env.ANTHROPIC_BASE_URL || "default",
+      status,
+      message,
+    });
+
+    // fall through to tool-based summary
   }
 
   const toolChoice = { type: "tool", name: "generate_summary" } as const;
@@ -140,7 +166,21 @@ export async function POST(request: Request) {
       tool_choice: toolChoice,
       stream: false as const,
     })) as unknown as { content: ContentBlock[] };
-  } catch {
+  } catch (err) {
+    const e = err as Record<string, unknown>;
+    const status = typeof e.status === "number" ? e.status : undefined;
+    const message = err instanceof Error ? err.message : String(err);
+
+    console.error("[summary] Upstream API error (tool attempt)", {
+      sessionId: body.sessionId,
+      language: body.language,
+      historyCount: body.history.length,
+      model: defaultModel,
+      baseURL: process.env.ANTHROPIC_BASE_URL || "default",
+      status,
+      message,
+    });
+
     response = null;
   }
 


### PR DESCRIPTION
目的：生产环境出现‘API额度用尽/调用失败’时，Vercel Logs 里能看到真实 upstream 错误（status/message/baseURL/model 等），方便定位是 401/429/5xx/网络。

变更：
- /api/brainstorm 和 /api/summary 在 production 也会 console.error 关键错误信息（不打印 API key，不打印用户内容）。